### PR TITLE
limit filesystem access

### DIFF
--- a/io.github.kukuruzka165.materialgram.yml
+++ b/io.github.kukuruzka165.materialgram.yml
@@ -5,7 +5,6 @@ sdk: org.freedesktop.Sdk
 command: materialgram
 rename-icon: materialgram
 finish-args:
-  - --filesystem=host
   - --share=ipc
   - --share=network
   - --socket=wayland
@@ -18,6 +17,7 @@ finish-args:
   - --talk-name=com.canonical.indicator.application
   - --talk-name=org.ayatana.indicator.application
   - --filesystem=xdg-run/pipewire-0
+  - --filesystem=home:ro
   - --unset-env=QT_PLUGIN_PATH
   - --env=PATH=/app/lib/webview/bin:/app/bin:/usr/bin
 sdk-extensions:


### PR DESCRIPTION
Previously --filesystem=host was added to fix file drag and drop functionality, limiting it now to now at least to the home directory with read-only permission