### PR TITLE
Update io.github.kukuruzka165.materialgram.yml

### DIFF
--- a/io.github.kukuruzka165.materialgram.yml
+++ b/io.github.kukuruzka165.materialgram.yml
@@ -17,7 +17,7 @@ finish-args:
   - --talk-name=com.canonical.indicator.application
   - --talk-name=org.ayatana.indicator.application
   - --filesystem=xdg-run/pipewire-0
-  - --filesystem=home:ro
+  - --filesystem=home:create
   - --unset-env=QT_PLUGIN_PATH
   - --env=PATH=/app/lib/webview/bin:/app/bin:/usr/bin
 sdk-extensions:


### PR DESCRIPTION
The permission to acess home directory has been set to :create instead of :ro .  Read only home will lead to failure in uploading and downloading files if caching limit is exceeded.
People do not know about flatseal app, which is used to set permissions in flatpak. Without this, they would not be able to download anything in /home/Downloads under /home directory in Linux after a fresh install via flatpak.